### PR TITLE
Fix issues for data refresh by applying query invalidation

### DIFF
--- a/src/ProductLibrary/cart.hook.ts
+++ b/src/ProductLibrary/cart.hook.ts
@@ -1,10 +1,15 @@
-import { useQuery, useMutation } from 'react-query';
+import { useQuery, useQueryClient, useMutation } from 'react-query';
 import {User} from 'shared/types/user';
 import {Cart} from 'shared/types/cart';
 import {Product} from 'shared/types/product';
 import {getCart, createCart, updateCart} from 'shared/apis/cart';
 
 const useCart = (user: User) => {
+  const queryClient = useQueryClient();
+  const mutationResetOptions = {
+    onSuccess: () => queryClient.invalidateQueries(),
+    onError: () => queryClient.invalidateQueries()
+  };
   const cartQuery = useQuery<Cart>(
     ['cart', user.id],
     () => getCart(user.id)
@@ -12,11 +17,11 @@ const useCart = (user: User) => {
   const { 
     isLoading: isCreatingCart, 
     mutate: createCartMutation
-  } = useMutation(createCart);
+  } = useMutation(createCart, mutationResetOptions);
   const { 
     isLoading: isUpdatingCart, 
     mutate: updateCartMutation
-  } = useMutation(updateCart);
+  } = useMutation(updateCart, mutationResetOptions);
   const handleUpdateCart = (newProduct: Product) => {
     const { data } = cartQuery;
     const cartProductIndex = data?.products.findIndex((product) => product.id === newProduct.id);

--- a/src/ProductLibrary/product-library.hook.ts
+++ b/src/ProductLibrary/product-library.hook.ts
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useState} from 'react';
-import { useQuery, useMutation } from 'react-query';
+import { useQuery, useQueryClient, useMutation } from 'react-query';
 import {LibraryAction, PRODUCT_DISPLAY_LIMIT} from 'ProductLibrary/product-library.constants';
 import {Product} from 'shared/types/product';
 import {
@@ -14,9 +14,11 @@ const useProductLibrary = () => {
   const [page, setPage] = useState<number>(1);
   const [selectedProductAction, setSelectedProductAction] = useState<LibraryAction>();
   const [selectedProduct, setSelectedProduct] = useState<Product | undefined>(undefined);
+  const queryClient = useQueryClient();
   const resetOpretationsState = () => {
     setSelectedProductAction(undefined);
     setSelectedProduct(undefined);
+    queryClient.invalidateQueries();
   };
   const mutationResetOptions = {
     onSuccess: () => resetOpretationsState(),
@@ -39,7 +41,9 @@ const useProductLibrary = () => {
     isLoading: isUpdatingProduct, 
     mutate: updateProductMutation
   } = useMutation(updateProduct, mutationResetOptions);
-  const { mutate: deleteProductMutation } = useMutation(deleteProduct);
+  const { 
+    mutate: deleteProductMutation 
+  } = useMutation(deleteProduct, mutationResetOptions);
   const { refetch } = productsQuery;
   const onAction = useCallback((type: LibraryAction, payload: any) => {
     const handlers: Record<LibraryAction, Function> = {


### PR DESCRIPTION
## Summary of changes
- Data invalidation should be applicable to product list and cart data queries so that user can see the updated lists always after create/update/delete operations performed by him.
 